### PR TITLE
Update elasticsearch

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var _ = require('elasticsearch/src/lib/utils');
+var _ = require('lodash');
 var elasticsearch = require('elasticsearch');
 var moment = require('moment');
 
@@ -24,7 +24,7 @@ exports.handler = function(event, context, callback) {
   };
 
   if (awsRegion !== undefined) {
-    config = _.deepMerge(config, {
+    config = _.merge(config, {
       amazonES: {
         credentials: new AWS.EnvironmentCredentials('AWS'),
         region: awsRegion,
@@ -43,11 +43,11 @@ exports.handler = function(event, context, callback) {
 }
 
 function getIndices(client) {
-  return client.indices.getAliases();
+  return client.cat.indices({h: ['index']});
 }
 
 function extractIndices(results) {
-  return Object.keys(results);
+  return results.split('\n')
 }
 
 function filterIndices(indices) {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
   "author": "Marty Zalega <marty@zalega.me>",
   "license": "MIT",
   "dependencies": {
-    "elasticsearch": "^12.1.3",
+    "elasticsearch": "git+https://github.com/elastic/elasticsearch-js#master",
     "http-aws-es": "^1.1.3",
+    "lodash": "^4.17.4",
     "moment": "^2.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Marty Zalega <marty@zalega.me>",
   "license": "MIT",
   "dependencies": {
-    "elasticsearch": "^11.0.1",
+    "elasticsearch": "^12.1.3",
     "http-aws-es": "^1.1.3",
     "moment": "^2.12.0"
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Marty Zalega <marty@zalega.me>",
   "license": "MIT",
   "dependencies": {
-    "elasticsearch": "git+https://github.com/elastic/elasticsearch-js#master",
+    "elasticsearch": "git+https://github.com/elastic/elasticsearch-js#adb3de5b3b56d2dd257e5af4204f4713e4ce55e4",
     "http-aws-es": "^1.1.3",
     "lodash": "^4.17.4",
     "moment": "^2.12.0"


### PR DESCRIPTION
This updates the elasticsearch library to support at least 5.1.

The API has changed, making a couple of changes necessary:
1. `indices.getAliases` is no longer a function. The preferred way to get the indices is with `cat.indices`.
2. The curator used internals of the elasticsearch library that have changed. These have been changed to use `lodash` instead.